### PR TITLE
Add @font-face that combines normal and italic fonts

### DIFF
--- a/font-faces/mono.css
+++ b/font-faces/mono.css
@@ -1,0 +1,16 @@
+@font-face {
+    font-family: 'GeistMono-Variable';
+    src: url('../fonts/mono/GeistMono[wght].woff2') format('woff2');
+    font-weight: 100 900;
+    font-style: normal;
+    font-display: swap;
+    font-synthesis: none;
+}
+@font-face {
+    font-family: 'GeistMono-Variable';
+    src: url('../fonts/mono/GeistMono-Italic[wght].woff2') format('woff2');
+    font-weight: 100 900;
+    font-style: italic;
+    font-display: swap;
+    font-synthesis: none;
+}

--- a/font-faces/sans.css
+++ b/font-faces/sans.css
@@ -1,0 +1,16 @@
+@font-face {
+    font-family: 'Geist-Variable';
+    src: url('../fonts/sans/Geist[wght].woff2') format('woff2');
+    font-weight: 100 900;
+    font-style: normal;
+    font-display: swap;
+    font-synthesis: none;
+}
+@font-face {
+    font-family: 'Geist-Variable';
+    src: url('../fonts/sans/Geist-Italic[wght].woff2') format('woff2');
+    font-weight: 100 900;
+    font-style: italic;
+    font-display: swap;
+    font-synthesis: none;
+}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "fonts"
   ],
   "exports": {
-    ".": "./font-faces/sans-var.css",
+    ".": "./font-faces/sans.css",
+    "./sans": "./font-faces/sans-var.css",
     "./italic": "./font-faces/sans-var-italic.css",
+    "./m": "./font-faces/mono.css",
     "./mono": "./font-faces/mono-var.css",
     "./mono-italic": "./font-faces/mono-var-italic.css",
     "./font-faces/": "./font-faces/"


### PR DESCRIPTION
Currently, if you want to use both normal and italic fonts in your project using this package, you must manually specify each font family.

```css
html {
  font-family: 'Geist-Variable';
}
i {
  font-family: 'Geist-VariableItalic';
}
```

Resolves the issue by adding a CSS file that merges font families into one.

The exports in package.json are redefined as follows:

* `non.geist` (added)
* `non.geist` -> `non.geist/sans`
* `non.geist/italic`
* `non.geist/m` (added)
* `non.geist/mono`
* `non.geist/mono-italic`

If there is a better suffix, please update.

Thanks for this package!